### PR TITLE
Improves speed by adding a timeout option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ pip install netaddr
 ## Usage
 
 ```
-usage: cymru-asnmap.py [-h] [-f] [-o FILENAME] target
+usage: cymru-asnmap.py [-h] [-f] [-t TIMEOUT] [-o FILENAME] target
 
 positional arguments:
-  target                Target to be queried.
+  target                Target to be queried (CIDR or filename).
 
 optional arguments:
   -h, --help            show this help message and exit
-  -f, --file            Load IPs from a file.
+  -f, --file            Loads the IPs from a file.
+  -t TIMEOUT, --timeout TIMEOUT
+                        Timeout (default is 5).
   -o FILENAME, --output FILENAME
-                        Output CSV file.
+                        Output CSV file
 ```
 
 ### Examples

--- a/cymru-asnmap.py
+++ b/cymru-asnmap.py
@@ -116,9 +116,10 @@ def main():
         print response
 
         to_csv(response, filename)
+        print "Output saved to: %s" % filename
 
     except Exception as e:
-        print "[!] Unable to proceed. Error: %s" % e
+        print "Unable to proceed. Error: %s" % e
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This pull request is to resolve #1 .

By defaul, the sockets module uses the default system timeout (20s for Linux).

A timeout options was added, with default value of 5s, so the user can set his/hers own timeout as desired.

Using a timeout of 1s, the average time for a query is 1.4s (including parsing the output and saving to the CSV file). Example:

daniel@toolbox:~/research/cymru-asnmap$ time python cymru-asnmap.py -t 1 <redacted>
<.snip.>
real    0m1.424s
user    0m0.048s
sys 0m0.008s 
